### PR TITLE
docs(readme): update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ screen -S aztec
 aztec start --node --archiver --sequencer \
   --network alpha-testnet \
   --l1-rpc-urls RPC_URL  \
-  --l1-consensus-host-urls BEACON_URL \
+  --l1-consensus-host-urls "BEACON_URL" \
   --sequencer.validatorPrivateKey 0xYourPrivateKey \
   --sequencer.coinbase 0xYourAddress \
   --p2p.p2pIp IP


### PR DESCRIPTION
Add quote to prevent --sequencer.validatorPrivateKey: command not found error
Note:
When i run this command on my azure vps it said that error so i asked people on aztec discord they said that i need to add quote.
After add quote and everything work perfectly